### PR TITLE
Allow for targeted, multi-file, analysis uploads to a session or collection.

### DIFF
--- a/matlab/@scitran/put.m
+++ b/matlab/@scitran/put.m
@@ -35,17 +35,28 @@ upType = p.Results.upType;
 stData = p.Results.stData;
 id     = p.Results.id;
 
+% Format upType
+upType(lower(upType) == ' ') = [];
+
 %% Do relevant upload
-switch upType
-    case 'analysis'
-        
+switch  lower(upType)
+    case {'analysis', 'sessionanalysis', 'collectionanalysis'}
+
         % Analysis upload to a collection or session.
         % In this case, the id needed to be set
-        
-        % Construct the command to upload one input file and one output file
-        inAnalysis  = fullfile(pwd, 'input', stData.inputs{1}.name);
-        outAnalysis = fullfile(pwd, 'output',stData.outputs{1}.name);
-        
+
+        % Construct the command to upload input and output files of any
+        % length % TODO: These should exist.
+        inAnalysis = '';
+        for ii = 1:numel(stData.inputs)
+            inAnalysis = strcat(inAnalysis, sprintf(' -F "file%s=@%s" ', num2str(ii), stData.inputs{ii}.name));
+        end
+
+        outAnalysis = '';
+        for ii = 1:numel(stData.outputs)
+            outAnalysis = strcat(outAnalysis, sprintf(' -F "file%s=@%s" ', num2str(ii + numel(stData.inputs)), stData.outputs{ii}.name));
+        end
+
         % We have to pad the json struct or savejson will not give us a list
         if length(stData.inputs) == 1
             stData.inputs{end+1}.name = '';
@@ -53,68 +64,89 @@ switch upType
         if length(stData.outputs) == 1
             stData.outputs{end+1}.name = '';
         end
-        
-        % Jsonify the payload, assuming it is necessary
+
+        % Remove full the full path, leaving only the file name, from input
+        % and output name fields.
+        for ii = 1:numel(stData.inputs)
+            [~, f, e] = fileparts(stData.inputs{ii}.name);
+            stData.inputs{ii}.name = [f, e];
+        end
+        for ii = 1:numel(stData.outputs)
+            [~, f, e] = fileparts(stData.outputs{ii}.name);
+            stData.outputs{ii}.name = [f, e];
+        end
+
+        % Jsonify the payload (assuming it is necessary)
         if isstruct(stData)
             stData = savejson('',stData);
-            stData = strrep(stData, '"', '\"');   % Escape the " or the cmd will fail.
+            % Escape the " or the cmd will fail.
+            stData = strrep(stData, '"', '\"');
         end
-        
-        curlCmd = sprintf('curl -F "file1=@%s" -F "file2=@%s" -F "metadata=%s" %s/api/collections/%s/analyses -H "Authorization":"%s"', inAnalysis, outAnalysis, stData, obj.url, id, obj.token );
-        
+
+        % Set the target for the analysis upload (collection or session)
+        if strfind(upType, 'collection')
+            target = 'collections';
+        elseif strfind(upType, 'session')
+            target = 'sessions';
+        else
+            error('No analysis target was specified. Options are: (1) Session Analysis (2) Collection Analysis')
+        end
+
+        curlCmd = sprintf('curl %s %s -F "metadata=%s" %s/api/%s/%s/analyses -H "Authorization":"%s"', inAnalysis, outAnalysis, stData, obj.url, target, id, obj.token ); %#ok<PFCEL>
+
         %% Execute the curl command with all the fields
-        
+
         stCurlRun(curlCmd);
-        
+
    case {'files','file'}
-        
+
         % Not checked.  Do with LMP.
-        
+
         % Handle permalinks which may have '?user='
         pLink = strsplit(pLink, '?');
         pLink = pLink{1};
-        
+
         % Build the url from the permalink by removing the endpart
         url = fileparts(pLink);
-        
+
         % Get the URL with the file name appended to it
         [~,n,e] = fileparts(fName);
         urlAndName = fullfile(url,[n,e]);
-        
-        
-        %% Gemerate MD5 checksum
-        
+
+
+        %% Generate MD5 checksum
+
         % MAC
         if ismac
             md5_cmd = sprintf('md5 %s',fName);
             [md5_status, md5_result] = system(md5_cmd);
             checkSum = md5_result(end-32:end-1);
-            
-            % Linux
+
+        % Linux
         elseif (isunix && ~ismac)
             md5_cmd = sprintf('md5sum %s',fName);
             [md5_status, md5_result] = system(md5_cmd);
             checkSum = md5_result(1:32);
-            
-            % Other/Unknown
+
+        % Other/Unknown
         else
             error('Unsupported system.\n');
         end
-        
+
         % Check that it worked
         if md5_status
             error('System checksum command failed');
         end
-        
-        
+
+
         %% Build and execute the curl command
-        
+
         curl_cmd = sprintf('/usr/bin/curl -v -X PUT --data-binary @%s -H "Content-MD5:%s" -H "Content-Type:application/octet-stream" -H "Authorization:%s" "%s?flavor=attachment"\n', fName, checkSum, token, urlAndName);
-        
+
         % Execute the command
         fprintf('Sending... ');
         [status, result] = stCurlRun(curl_cmd);
-        
+
         % Let the user know if it worked
         if status
             warning('Upload failed');
@@ -122,7 +154,7 @@ switch upType
         else
             fprintf('File sucessfully uploaded.\n');
         end
-        
+
      otherwise
         error('Unknown upload type %s\n',upType);
 end

--- a/matlab/@scitran/search.m
+++ b/matlab/@scitran/search.m
@@ -27,7 +27,7 @@ srch  = p.Results.srch;
 oFile = p.Results.oFile;
 
 
-%% The srch is a Matlab structure containing the search requirements. 
+%% The srch is a Matlab structure containing the search requirements.
 
 % It is converted to json here.  But, we accept either a struct or a json
 % notation for the srch.
@@ -76,14 +76,14 @@ srchType = fieldnames(srchResult);
 switch srchType{1}
     % TODO:  Sort several of these by their label before returning.
     case 'projects'
-        nProjects = length(srchResult.projects);  
+        nProjects = length(srchResult.projects);
         result = cell(1,nProjects);
-        for ii=1:nProjects          
+        for ii=1:nProjects
             result{ii}.id     = srchResult.projects{ii}.x0x5F_id;
             result{ii}.type   = srchResult.projects{ii}.x0x5F_type;
             result{ii}.source = srchResult.projects{ii}.x0x5F_source;
             result{ii}.score  = srchResult.projects{ii}.x0x5F_score;
-            result{ii}.index  = srchResult.projects{ii}.x0x5F_index;        
+            result{ii}.index  = srchResult.projects{ii}.x0x5F_index;
         end
     case 'sessions'
         nSessions = length(srchResult.sessions);
@@ -143,13 +143,16 @@ end
 
 % The files might be part of an acquisition, or part of a session, or part
 % of a project.  So many files, so little time.
+% TODO: Handle session and project attachments
 if strcmp(srchType,'files')
     n = length(result);
     for ii=1:n
         cname = result{ii}.source.container_name;
-        acquisitionid    = result{ii}.source.acquisition.x0x5F_id;
-        fname = result{ii}.source.name;
-        result{ii}.plink = sprintf('%s/api/%s/%s/files/%s',obj.url, cname, acquisitionid, fname);
+        if strcmpi(cname, 'acquisitions') % Only add files from acquisitions to result
+            acquisitionid = result{ii}.source.acquisition.x0x5F_id;
+            fname = result{ii}.source.name;
+            result{ii}.plink = sprintf('%s/api/%s/%s/files/%s',obj.url, cname, acquisitionid, fname);
+        end
     end
 end
 

--- a/matlab/@scitran/searchCmd.m
+++ b/matlab/@scitran/searchCmd.m
@@ -11,7 +11,7 @@ function cmd  = searchCmd(obj,srch,varargin)
 %
 % Example
 %    st.searchCmd(srch)
-% 
+%
 % BW, Scitran Team, 2016
 
 %% Decode input arguments
@@ -30,14 +30,8 @@ srch   = p.Results.srch;
 oFile = [tempname, '.json'];
 
 %% Build the command
-
-% Set the number of search results desired (does not work with collection
-% searches)
-% Ask LMP what to do about this issue
-% num_results = 50;
-
-cmd = sprintf('curl -XPOST "%s/api/search" -H "Authorization":"%s" -k -d ''%s'' > %s && echo "%s"',...
+cmd = sprintf('curl -s -XPOST "%s/api/search" -H "Authorization":"%s" -k -d ''%s'' > %s && echo "%s"',...
     obj.url, obj.token, srch, oFile, oFile);
-    
-    
+
+
 end

--- a/matlab/utility/stCurlRun.m
+++ b/matlab/utility/stCurlRun.m
@@ -60,8 +60,8 @@ end
 %% Run the curl command
 
 [status, result] = system(args.curl_command);
-if status ~= 0
-    fprintf('stCulrRun error: %s\n', result);
+if status ~= 0 || ~isempty(strfind(lower(result), 'status_code'))
+    warning('stCulrRun: %s\n', result);
 end
 
 %% Reset the ENV

--- a/matlab/utility/stDirCreate.m
+++ b/matlab/utility/stDirCreate.m
@@ -4,8 +4,11 @@ function stDirCreate(d)
 % LMP,BW Vistasoft Team, 2016
 
 % Check for exitence.  If there, empty it.  If not there, create it.
-if exist(d,'dir'),     delete(fullfile(d,'*'))
-else                   mkdir(d);
+if exist(d,'dir')
+    rmdir(d, 's');
+    mkdir(d);
+else
+    mkdir(d);
 end
 
 end


### PR DESCRIPTION
These changes will allow: 
1. the user to specify if they want to upload a given analysis object to a session, or a collection (previously only collections could receive analyses) 
2. an arbitrary number of files to be uploaded (previously limited to a single input/output) as inputs or outputs. 

The s_stGear.m example script is also updated to reflect this new functionality. 
