### PR TITLE
Update default sdk install to latest version

### DIFF
--- a/utility/stFlywheelSDK.m
+++ b/utility/stFlywheelSDK.m
@@ -65,7 +65,7 @@ function [status, url, toolboxTable] = stFlywheelSDK(action,varargin)
 p = inputParser;
 varargin = stParamFormat(varargin);
 p.addRequired('action',@ischar);
-p.addParameter('sdkversion','2.5.0',@ischar);
+p.addParameter('sdkversion','4.1.0',@ischar);
 p.addParameter('summary',true,@islogical);
 
 p.parse(action,varargin{:});


### PR DESCRIPTION
Basic functionality should be tested with this version prior to merge. 

https://github.com/flywheel-io/core/releases/tag/4.1.0

# Features
- Sdk gear rules
- Add regex operator to pagination filter
- Allow after_id to be blank, don't overwrite filter

# Fixes
- Tab completion of object attributes in Matlab SDK
- Model to struct conversion in Matlab SDK
- Allow assigning to empty model properties in Matlab SDK
- Added schema for getJobConfig
- Auth config is replace instead of update